### PR TITLE
Adds coverage for appending symbols to the current context and for symbol tables with null slots.

### DIFF
--- a/iontestdata/good/equivs/localSymbolTableAppend.ion
+++ b/iontestdata/good/equivs/localSymbolTableAppend.ion
@@ -1,0 +1,80 @@
+// Tests several uses of appending symbols to the current local symbol table context.
+
+embedded_documents::[
+    "s1 s2 s1 s2 s3 s4 s5",
+
+    // The basic case.
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s1", "s2"]'''
+    '''}'''
+    '''$10 $11 '''
+    '''$ion_symbol_table::{'''
+    '''    imports:$ion_symbol_table,'''
+    '''    symbols:["s3", "s4", "s5"]'''
+    '''}'''
+    '''$10 $11 $12 $13 $14''',
+
+    // Appending symbols can occur multiple times in the same stream. The 'symbols' and 'imports' fields can come in
+    // any order.
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s1"]'''
+    '''}'''
+    '''$10 '''
+    '''$ion_symbol_table::{'''
+    '''    imports:$ion_symbol_table,'''
+    '''    symbols:["s2"]'''
+    '''}'''
+    '''$11 '''
+    '''$ion_symbol_table::{'''
+    '''    imports:$3,'''
+    '''    symbols:["s3", "s4"]'''
+    '''}'''
+    '''$10 $11 $12 '''
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s5"],'''
+    '''    imports:$ion_symbol_table,'''
+    '''}'''
+    '''$13 $14''',
+
+    // Appending zero symbols is legal.
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s1", "s2", "s3", "s4", "s5"]'''
+    '''}'''
+    '''$10 $11 '''
+    '''$ion_symbol_table::{'''
+    '''    imports:$ion_symbol_table,'''
+    '''    symbols:[]'''
+    '''}'''
+    '''$10 $11 $12 $13 $14''',
+
+    // Appending symbols must incorporate symbols that were previously imported. Null slots need to be treated as SID
+    // gaps, as usual.
+
+    '''$ion_symbol_table::{'''
+    '''    imports: [ { name: "foo", version: 1, max_id: 10}],'''
+    '''    symbols: ["s1"]'''
+    '''}'''
+    '''$20 '''
+    '''$ion_symbol_table::{'''
+    '''    imports:$ion_symbol_table,'''
+    '''    symbols:["s2", null.string, "s3", "s4", "s5"]'''
+    '''}'''
+    '''$21 $20 $21 $23 '''
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s3", "s4", "s5"]'''
+    '''}'''
+    '''$11 $12''',
+
+    // When the current symbol table is the system symbol table and the value of the imports field is the symbol
+    // $ion_symbol_table, processing is identical to having no imports field value.
+
+    '''$ion_symbol_table::{'''
+    '''    imports: $ion_symbol_table,'''
+    '''    symbols: ["s1", "s2", "s3", "s4", "s5"]'''
+    '''}'''
+    '''$10 $11 $10 $11 $12 $13 $14'''
+
+]

--- a/iontestdata/good/equivs/localSymbolTableNullSlots.ion
+++ b/iontestdata/good/equivs/localSymbolTableNullSlots.ion
@@ -1,0 +1,23 @@
+// Verifies that null elements in the symbols list declare unknown symbol text (“gaps”) for its SID within the sequence,
+// and that any element of the list that is not a string must be interpreted as if it were null.
+
+embedded_documents::[
+    "s1 s2 s3",
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s1", "s2", null.string, "s3"]'''
+    '''}'''
+    '''$10 $11 $13''',
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:[42, "s1", "s2", "s3"]'''
+    '''}'''
+    '''$11 $12 $13''',
+
+    '''$ion_symbol_table::{'''
+    '''    symbols:["s1", $3, "s2", null, "s3", 123.4e5],'''
+    '''    imports:[ {name: "foo", version: 1, max_id: 10} ]'''
+    '''}'''
+    '''$20 $22 $24'''
+
+]


### PR DESCRIPTION
* When a new local symbol table is declared, it may append symbols to the previous context instead of resetting the context if the value of its `imports` field is `$ion_symbol_table`.
* Null or non-string elements in a symbol table's`symbols` list are assigned symbol IDs and are considered to have unknown text.