### PR TITLE
Adds coverage for local symbol tables with user annotations.

### DIFF
--- a/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion
+++ b/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion
@@ -1,0 +1,30 @@
+// Local symbol table structs may have additional annotations as long as the $ion_symbol_table annotation comes first.
+// Additionally, values within the local symbols struct may be annotated.
+// See also: good/nonequivs/localSymbolTableWithAnnotations.ion
+
+embedded_documents::[
+    '''
+    $ion_1_0
+    $ion_symbol_table::{
+        symbols:["foo", "bar"]
+    }
+    $10 $11
+    ''',
+
+    '''
+    $ion_1_0
+    $ion_symbol_table::annotated::{
+        symbols:["foo", "bar"]
+    }
+    $10 $11
+    ''',
+
+    '''
+    $ion_1_0
+    $ion_symbol_table::annotated::{
+        symbols:abc::["foo", def::"bar"]
+    }
+    $10 $11
+    '''
+]
+

--- a/iontestdata/good/non-equivs/localSymbolTableWithAnnotations.ion
+++ b/iontestdata/good/non-equivs/localSymbolTableWithAnnotations.ion
@@ -1,0 +1,21 @@
+// If local symbol table structs have additional annotations, $ion_symbol_table must be the first. Otherwise, the struct
+// is treated as a user value.
+// See also: good/equivs/localSymbolTableWithAnnotations.ion
+
+embedded_documents::[
+    '''
+    $ion_1_0
+    $ion_symbol_table::{
+        symbols:["foo", "bar"]
+    }
+    foo bar
+    ''',
+
+    '''
+    $ion_1_0
+    annotated::$ion_symbol_table::{
+        symbols:["foo", "bar"]
+    }
+    foo bar
+    '''
+]


### PR DESCRIPTION
Local symbol table structs may have additional annotations as long as the $ion_symbol_table annotation comes first. Additionally, values within the local symbols struct may be annotated. See the very bottom of http://amzn.github.io/ion-docs/symbols.html .