### PR TITLE
Adds coverage for symbol tokens with prefixes that match keywords.

### DIFF
--- a/iontestdata/good/equivs/keywordPrefixes.ion
+++ b/iontestdata/good/equivs/keywordPrefixes.ion
@@ -1,0 +1,65 @@
+// Tests that the keyword lexer does not simply match keyword prefixes and that any lookahead logic works correctly.
+(
+    {falsehood: ""}
+    {'falsehood': ""}
+)
+(
+    {truer: 123}
+    {'truer': 123}
+)
+(
+    {nancy: abc}
+    {'nancy': abc}
+)
+(
+    {nullable: 3.14}
+    {'nullable': 3.14}
+)
+(
+    falsehood::""
+    'falsehood'::""
+)
+(
+    truer::123
+    'truer'::123
+)
+(
+    nancy::abc
+    'nancy'::abc
+)
+(
+    nullable::3.14
+    'nullable'::3.14
+)
+(
+    falsehood
+    'falsehood'
+)
+(
+    truer
+    'truer'
+)
+(
+    nancy
+    'nancy'
+)
+(
+    nullable
+    'nullable'
+)
+embedded_documents::(
+    "falsehood"
+    "'falsehood'"
+)
+embedded_documents::(
+    "truer"
+    "'truer'"
+)
+embedded_documents::(
+    "nancy"
+    "'nancy'"
+)
+embedded_documents::(
+    "nullable"
+    "'nullable'"
+)


### PR DESCRIPTION
*Description of changes:*
Tests that the keyword lexer does not simply match keyword prefixes and that any lookahead logic works correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
