### PR TITLE
Adds a good/equivs test for long strings with concatenated components separated by comments.

### DIFF
--- a/iontestdata/good/equivs/longStringsWithComments.ion
+++ b/iontestdata/good/equivs/longStringsWithComments.ion
@@ -1,0 +1,21 @@
+// Concatenated long strings with comments between literals
+[
+    '''foobar''',
+    '''foo'''
+    '''bar''',
+    '''foo'''
+
+    '''bar''',
+    '''foo''' // This comment does not prevent concatenation.
+    '''bar''',
+    '''foo''' /* This comment does not prevent concatenation. */ '''bar''',
+    '''foo'''
+    // This comment does not prevent concatenation.
+    '''bar''',
+    '''foo'''
+    /* This comment does not prevent concatenation. */
+    '''bar''',
+    '''foo''' // This comment
+              /* does not prevent concatenation
+               */'''bar''',
+]


### PR DESCRIPTION
*Issue #, if available:*
Prompted by ion-c bug [147](https://github.com/amzn/ion-c/issues/147).
Fixes #51 

*Description of changes:*
Ensures that separating long string components with comments does not prevent them from being concatenated to form a single value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
