### PR TITLE
Adds a good/equivs test for text clobs with various equivalent newline sequences.

### DIFF
--- a/iontestdata/good/equivs/clobNewlines.ion
+++ b/iontestdata/good/equivs/clobNewlines.ion
@@ -1,0 +1,129 @@
+// WARNING! This file has inconsistent newlines!
+// Some lines have CR LF, some have LF.
+// Ion parsers must normalize newlines in clob to LF.
+
+
+// These clobs are empty: the linefeeds are escaped.
+[
+{{""}},
+
+// This has LF escaped-away
+{{"\
+"}},
+
+// This has CR LF escaped-away
+{{"\
+"}},
+
+// This has CR escaped-away
+{{"\"}},
+
+// This has LF escaped-away
+{{'''\
+'''}},
+
+// This has CR LF escaped-away
+{{'''\
+'''}},
+
+// This has CR escaped-away
+{{'''\'''}},
+]
+
+
+// These clobs include the newline codepoint.
+[
+{{"\n"}},
+{{'''\n'''}},
+{{"\x0a"}},
+{{"\x0A"}},
+
+// This has LF
+{{'''
+'''}},
+
+// This has CR LF
+{{'''
+'''}},
+
+// This has CR
+{{''''''}},
+]
+
+
+// These clobs include two newline codepoints.
+[
+{{"\n\n"}},
+
+// This has LF
+{{'''\n
+'''}},
+
+// This has CR LF
+{{'''\n
+'''}},
+
+// This has LF CR
+{{'''
+'''}},
+
+// This has CR
+{{'''\n'''}},
+
+// This has CR CR
+{{''''''}},
+
+// This has CR CR LF
+{{'''
+'''}},
+]
+
+
+[
+{{"x"}},
+
+// This has LF escaped-away
+{{"x\
+"}},
+
+// This has CR LF escaped-away
+{{"x\
+"}},
+
+// This has CR escaped-away
+{{"x\"}},
+]
+
+
+// Now we need to be careful with escapes.
+[
+{{"\r\n"}},
+
+// This has LF
+{{'''\r
+'''}},
+
+// This has CR LF
+{{'''\r
+'''}},
+
+// This has CR
+{{'''\r'''}},
+]
+
+
+// Now we need to be careful with escapes.
+[
+{{"\r\n"}},
+
+// This has LF
+{{"\r\
+\n"}},
+
+// This has CR LF
+{{"\r\
+\n"}},
+
+// This has CR
+{{"\r\\n"}},
+]


### PR DESCRIPTION
*Description of changes:*
Identical to [equivs/textNewlines.ion](https://github.com/amzn/ion-tests/blob/master/iontestdata/good/equivs/textNewlines.ion), but for clobs. My assertion is that clob literals should have the same newline normalization rules as string and symbol literals, although the spec is unclear about this. The spec should be clarified as a follow-on task.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
