### PR TITLE
Correct .10n test descriptions in bad test README

### DIFF
--- a/iontestdata/bad/README.md
+++ b/iontestdata/bad/README.md
@@ -102,7 +102,7 @@ are available.
 minLongWithLenTooSmall.10n
 --------------------------
 Contains an Int whose length is specified as 7 bytes, but contains 8 bytes of
-data. The trailing byte is `0x00` (a Null with an invalid _L_ value).
+data. The trailing byte is `0x01`, indicating the start of a 2 byte NOP pad.
 
 negativeIntZero
 -----------------
@@ -116,10 +116,6 @@ nopPadTooShort.10n
 ------------------
 Contains a NOP pad with a declared length of 16 bytes that ends after only 15
 bytes.
-
-nullBadTD.10n
--------------
-Contains an Null with an invalid _L_ value of `0`.
 
 stringLenTooLarge.10n
 ---------------------


### PR DESCRIPTION
*Issue #, if available:* #60

*Description of changes:*
Remove nullBadTD because it refers to a test file that is no longer present (and no longer bad).
Correct the trailing byte in the description of minLongWithLenTooSmall because the description refers to the wrong byte.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
