### PR TITLE
Fix sign in field symbol

### DIFF
--- a/iontestdata/good/fieldNameQuotedNegInf.ion
+++ b/iontestdata/good/fieldNameQuotedNegInf.ion
@@ -1,1 +1,1 @@
-{ '+inf' : false }
+{ '-inf': false }


### PR DESCRIPTION
Sign was incorrect according to filename.

*Issue #, if available:*

Not sure if this is worthy of an issue.

*Description of changes:*

The test claims the sign for inf in the field should be -, but it was +.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
